### PR TITLE
Refactor using ReaderTaskEither

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^20.5.6",
     "@types/pg": "^8.10.2",
     "@typescript-eslint/eslint-plugin": "^6.4.1",
+    "@typescript-eslint/parser": "^6.7.2",
     "eslint": "^8.47.0",
     "prettier": "^2.8.8",
     "typescript": "^5.1.6"

--- a/src/config/deps.ts
+++ b/src/config/deps.ts
@@ -1,0 +1,13 @@
+import { KafkaProducerCompact } from "@pagopa/fp-ts-kafkajs/dist/lib/KafkaProducerCompact";
+import { PGClient } from "../database/postgresql/PostgresOperation";
+import { Student } from "../model/student";
+
+export interface QueueDeps {
+  messagingClient: KafkaProducerCompact<Student>;
+}
+
+export interface DatabaseDeps {
+  pgClient: PGClient;
+}
+
+export interface Deps extends QueueDeps, DatabaseDeps {}

--- a/src/database/postgresql/PostgresLogicalPg.ts
+++ b/src/database/postgresql/PostgresLogicalPg.ts
@@ -1,5 +1,6 @@
 import * as E from "fp-ts/Either";
 import * as TE from "fp-ts/TaskEither";
+import * as RTE from "fp-ts/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { Wal2Json } from "pg-logical-replication";
 import { AbstractPlugin } from "pg-logical-replication/dist/output-plugins/abstract.plugin";
@@ -7,32 +8,40 @@ import { PGClient } from "./PostgresOperation";
 
 export type PgEvents = "start" | "data" | "error" | "acknowledge" | "heartbeat";
 
-export const onDataEvent = (
-  client: PGClient,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  listener: (...args: any[]) => TE.TaskEither<Error, void>
-): TE.TaskEither<Error, void> =>
-  pipe(
-    TE.rightIO(() => {
-      client.pgLogicalClient.on("data", (lsn: string, log: Wal2Json.Output) => {
-        void listener(log)();
-      });
-    }),
-    TE.mapLeft(
-      (error) => new Error(`Error during data event subscription - ${error}`)
-    )
-  );
+export const onDataEvent =
+  (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    listener: (...args: any[]) => Promise<void>
+  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
+  ({ pgClient }) =>
+    pipe(
+      TE.rightIO(() => {
+        pgClient.pgLogicalClient.on(
+          "data",
+          (_: string, log: Wal2Json.Output) => {
+            listener(log).catch((error) => {
+              pgClient.pgLogicalClient.emit("error", error);
+            });
+          }
+        );
+      })
+    );
 
-export const subscribeToChanges = (
-  client: PGClient,
-  plugin: AbstractPlugin,
-  slotName: string
-): TE.TaskEither<Error, void> =>
-  pipe(
-    TE.tryCatch(async () => {
-      void client.pgLogicalClient.subscribe(plugin, slotName);
-    }, E.toError),
-    TE.mapLeft(
-      (error) => new Error(`Error subscribing to slot ${slotName} - ${error}`)
-    )
-  );
+export const subscribeToChanges =
+  (
+    plugin: AbstractPlugin,
+    slotName: string
+  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
+  ({ pgClient }) =>
+    pipe(
+      TE.tryCatch(
+        () =>
+          pgClient.pgLogicalClient
+            .subscribe(plugin, slotName)
+            .then(() => void 0),
+        E.toError
+      ),
+      TE.mapLeft(
+        (error) => new Error(`Error subscribing to slot ${slotName} - ${error}`)
+      )
+    );

--- a/src/database/postgresql/PostgresLogicalPg.ts
+++ b/src/database/postgresql/PostgresLogicalPg.ts
@@ -1,10 +1,9 @@
 import * as E from "fp-ts/Either";
 import * as TE from "fp-ts/TaskEither";
-import * as RTE from "fp-ts/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { Wal2Json } from "pg-logical-replication";
 import { AbstractPlugin } from "pg-logical-replication/dist/output-plugins/abstract.plugin";
-import { PGClient } from "./PostgresOperation";
+import { DatabaseDeps } from "../../config/deps";
 
 export type PgEvents = "start" | "data" | "error" | "acknowledge" | "heartbeat";
 
@@ -12,8 +11,8 @@ export const onDataEvent =
   (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     listener: (...args: any[]) => Promise<void>
-  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
-  ({ pgClient }) =>
+  ) =>
+  ({ pgClient }: DatabaseDeps) =>
     pipe(
       TE.rightIO(() => {
         pgClient.pgLogicalClient.on(
@@ -28,11 +27,8 @@ export const onDataEvent =
     );
 
 export const subscribeToChanges =
-  (
-    plugin: AbstractPlugin,
-    slotName: string
-  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
-  ({ pgClient }) =>
+  (plugin: AbstractPlugin, slotName: string) =>
+  ({ pgClient }: DatabaseDeps) =>
     pipe(
       TE.tryCatch(
         () =>

--- a/src/database/postgresql/PostgresOperation.ts
+++ b/src/database/postgresql/PostgresOperation.ts
@@ -1,9 +1,11 @@
 /* eslint-disable no-console */
 import { defaultLog, useWinston, withConsole } from "@pagopa/winston-ts";
 import * as TE from "fp-ts/TaskEither";
+import * as RTE from "fp-ts/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { Client, ClientConfig } from "pg";
 import { LogicalReplicationService } from "pg-logical-replication";
+
 useWinston(withConsole());
 
 export type PGClient = {
@@ -11,52 +13,46 @@ export type PGClient = {
   pgLogicalClient: LogicalReplicationService;
 };
 
-export const createPGClient = (
-  config: ClientConfig
-): TE.TaskEither<Error, PGClient> =>
-  TE.tryCatch(
-    async () => ({
-      pgClient: new Client(config),
-      pgLogicalClient: new LogicalReplicationService(config),
-    }),
-    (error) =>
-      pipe(
-        defaultLog.taskEither.error(`Error creating PG clients - ${error}`),
-        () => new Error(`Error creating PG clients - ${error}`)
-      )
-  );
+export const createPGClient =
+  (): RTE.ReaderTaskEither<{ pgClientConfig: ClientConfig }, Error, PGClient> =>
+  ({ pgClientConfig }) =>
+    TE.tryCatch(
+      async () => ({
+        pgClient: new Client(pgClientConfig),
+        pgLogicalClient: new LogicalReplicationService(pgClientConfig),
+      }),
+      (error) => new Error(`Error creating PG clients - ${error}`)
+    );
 
-export const connectPGClient = (client: PGClient): TE.TaskEither<Error, void> =>
-  TE.tryCatch(
-    async () => await client.pgClient.connect(),
-    (error) =>
-      pipe(
-        defaultLog.taskEither.error(`Error connecting to PG - ${error}`),
-        () => new Error(`Error connecting to PG - ${error}`)
-      )
-  );
+export const connectPGClient =
+  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
+  ({ pgClient }) =>
+    TE.tryCatch(
+      async () => await pgClient.pgClient.connect(),
+      (error) =>
+        pipe(
+          defaultLog.taskEither.error(`Error connecting to PG - ${error}`),
+          () => new Error(`Error connecting to PG - ${error}`)
+        )
+    );
 
-export const disconnectPGClient = (
-  client: PGClient
-): TE.TaskEither<Error, void> =>
-  TE.tryCatch(
-    async () => await client.pgClient.end(),
-    (error) => new Error(`Error disconnecting from PG - ${error}`)
-  );
+export const disconnectPGClient =
+  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
+  ({ pgClient }) =>
+    TE.tryCatch(
+      async () => await pgClient.pgClient.end(),
+      (error) => new Error(`Error disconnecting from PG - ${error}`)
+    );
 
-export const disconnectPGLogicalClient = (
-  client: PGClient
-): TE.TaskEither<Error, void> =>
-  TE.tryCatch(
-    async () => void (await client.pgLogicalClient.stop()),
-    (error) => new Error(`Error disconnecting from PG - ${error}`)
-  );
+export const disconnectPGLogicalClient =
+  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
+  ({ pgClient }) =>
+    TE.tryCatch(
+      async () => void (await pgClient.pgLogicalClient.stop()),
+      (error) => new Error(`Error disconnecting from PG - ${error}`)
+    );
 
-export const disconnectPGClientWithoutError = (
-  client: PGClient
-): TE.TaskEither<never, void> =>
-  pipe(
-    client,
-    disconnectPGClient,
-    TE.orElseW((_) => TE.right(undefined))
-  );
+export const disconnectPGClientWithoutError = pipe(
+  disconnectPGClient(),
+  RTE.orElseW(() => RTE.right(undefined))
+);

--- a/src/database/postgresql/PostgresOperation.ts
+++ b/src/database/postgresql/PostgresOperation.ts
@@ -5,6 +5,7 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { Client, ClientConfig } from "pg";
 import { LogicalReplicationService } from "pg-logical-replication";
+import { DatabaseDeps } from "../../config/deps";
 
 useWinston(withConsole());
 
@@ -14,8 +15,8 @@ export type PGClient = {
 };
 
 export const createPGClient =
-  (): RTE.ReaderTaskEither<{ pgClientConfig: ClientConfig }, Error, PGClient> =>
-  ({ pgClientConfig }) =>
+  () =>
+  ({ pgClientConfig }: { pgClientConfig: ClientConfig }) =>
     TE.tryCatch(
       async () => ({
         pgClient: new Client(pgClientConfig),
@@ -25,8 +26,8 @@ export const createPGClient =
     );
 
 export const connectPGClient =
-  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
-  ({ pgClient }) =>
+  () =>
+  ({ pgClient }: DatabaseDeps) =>
     TE.tryCatch(
       async () => await pgClient.pgClient.connect(),
       (error) =>
@@ -37,16 +38,16 @@ export const connectPGClient =
     );
 
 export const disconnectPGClient =
-  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
-  ({ pgClient }) =>
+  () =>
+  ({ pgClient }: DatabaseDeps) =>
     TE.tryCatch(
       async () => await pgClient.pgClient.end(),
       (error) => new Error(`Error disconnecting from PG - ${error}`)
     );
 
 export const disconnectPGLogicalClient =
-  (): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, void> =>
-  ({ pgClient }) =>
+  () =>
+  ({ pgClient }: DatabaseDeps) =>
     TE.tryCatch(
       async () => void (await pgClient.pgLogicalClient.stop()),
       (error) => new Error(`Error disconnecting from PG - ${error}`)

--- a/src/database/postgresql/PostgresPg.ts
+++ b/src/database/postgresql/PostgresPg.ts
@@ -1,15 +1,13 @@
-import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
-import { QueryResult } from "pg";
-import { PGClient } from "./PostgresOperation";
+import { DatabaseDeps } from "../../config/deps";
 
 export const query =
   (
     queryString: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     values?: any[]
-  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, QueryResult> =>
-  ({ pgClient }) =>
+  ) =>
+  ({ pgClient }: DatabaseDeps) =>
     TE.tryCatch(
       async () => await pgClient.pgClient.query(queryString, values),
       (error) => new Error(`Error executing query - ${error}`)

--- a/src/database/postgresql/PostgresPg.ts
+++ b/src/database/postgresql/PostgresPg.ts
@@ -1,14 +1,16 @@
+import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import { QueryResult } from "pg";
 import { PGClient } from "./PostgresOperation";
 
-export const query = (
-  client: PGClient,
-  queryString: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  values?: any[]
-): TE.TaskEither<Error, QueryResult> =>
-  TE.tryCatch(
-    async () => await client.pgClient.query(queryString, values),
-    (error) => new Error(`Error executing query - ${error}`)
-  );
+export const query =
+  (
+    queryString: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    values?: any[]
+  ): RTE.ReaderTaskEither<{ pgClient: PGClient }, Error, QueryResult> =>
+  ({ pgClient }) =>
+    TE.tryCatch(
+      async () => await pgClient.pgClient.query(queryString, values),
+      (error) => new Error(`Error executing query - ${error}`)
+    );


### PR DESCRIPTION
This is an example PR to showcase the usage of RederTaskEither.

In practice what you do is to invert the dependency arguments (ie. clients) in order to avoid to pass them around into integration pipelines (see main).
